### PR TITLE
Do not transform HTML code blocks with multiple children

### DIFF
--- a/src/Fixer/HtmlBlockFixer.php
+++ b/src/Fixer/HtmlBlockFixer.php
@@ -164,6 +164,10 @@ class HtmlBlockFixer extends AbstractFixer implements FixerInterface
                 }
             } elseif ('pre' === $element->tagName) {
                 foreach ($element->childNodes as $key => $child) {
+                    if ($child->childNodes->length !== 1) {
+                        $node = null;
+                        break;
+                    }
                     if ($child instanceof \DOMElement && 'code' === $child->tagName) {
                         $node = new FencedCode(0, '', 0);
                         $childAttributes = $this->getAttributes($child);

--- a/src/Fixer/HtmlBlockFixer.php
+++ b/src/Fixer/HtmlBlockFixer.php
@@ -164,8 +164,9 @@ class HtmlBlockFixer extends AbstractFixer implements FixerInterface
                 }
             } elseif ('pre' === $element->tagName) {
                 foreach ($element->childNodes as $key => $child) {
-                    if ($child->childNodes->length !== 1) {
+                    if (1 !== $child->childNodes->length) {
                         $node = null;
+
                         break;
                     }
                     if ($child instanceof \DOMElement && 'code' === $child->tagName) {

--- a/tests/data/code_block_html-out.html
+++ b/tests/data/code_block_html-out.html
@@ -1,10 +1,9 @@
 <pre><code class="language-javascript">{
-  &quot;example&quot;: &quot;example&quot;,
-  &quot;authors&quot;: [
-    &quot;John Appleseed &quot;
+  "example": "example",
+  "authors": [
+    "John Appleseed <john at="" example.com="">"
   ]
-}
-</code></pre>
+}</john></code></pre>
 <pre><code class="language-javascript">{
   &quot;example&quot;: &quot;example&quot;,
   &quot;authors&quot;: [

--- a/tests/data/code_block_html-out.md
+++ b/tests/data/code_block_html-out.md
@@ -1,11 +1,9 @@
-```javascript
-{
+<pre><code class="language-javascript">{
   "example": "example",
   "authors": [
-    "John Appleseed "
+    "John Appleseed <john at="" example.com="">"
   ]
-}
-```
+}</john></code></pre>
 
 ```javascript
 {

--- a/tests/data/html_code-in.md
+++ b/tests/data/html_code-in.md
@@ -1,0 +1,2 @@
+<pre><code class="language-bash">Some <strong>HTML</strong> goes here
+Some <em>HTML</em> goes here</code></pre>

--- a/tests/data/html_code-out.html
+++ b/tests/data/html_code-out.html
@@ -1,0 +1,2 @@
+<pre><code class="language-bash">Some <strong>HTML</strong> goes here
+Some <em>HTML</em> goes here</code></pre>

--- a/tests/data/html_code-out.md
+++ b/tests/data/html_code-out.md
@@ -1,0 +1,2 @@
+<pre><code class="language-bash">Some <strong>HTML</strong> goes here
+Some <em>HTML</em> goes here</code></pre>


### PR DESCRIPTION
Fixes the case when a code block has more than one child. In this case, the content cannot be transformed back to markdown, and pure HTML should be returned.