### PR TITLE
Fix HTML fenced code siblings management

### DIFF
--- a/src/Fixer/HtmlBlockFixer.php
+++ b/src/Fixer/HtmlBlockFixer.php
@@ -84,8 +84,12 @@ class HtmlBlockFixer extends AbstractFixer implements FixerInterface
                                 $exploded = explode($key, $newNode->getLiteral());
 
                                 if (2 === \count($exploded)) {
-                                    $className = $newNode::class;
-                                    $newNodes = [...\array_slice($newNodes, 0, $newNodeKey), new $className($exploded[0]), $replacement, new $className($exploded[1]), ...\array_slice($newNodes, $newNodeKey + 1)];
+                                    if ($newNode instanceof FencedCode) {
+                                        $newNode->setLiteral(str_replace($key, '', $newNode->getLiteral()));
+                                    } else {
+                                        $className = $newNode::class;
+                                        $newNodes = [...\array_slice($newNodes, 0, $newNodeKey), new $className($exploded[0]), $replacement, new $className($exploded[1]), ...\array_slice($newNodes, $newNodeKey + 1)];
+                                    }
                                 }
                             }
                         }

--- a/tests/data/attribute-class-in.md
+++ b/tests/data/attribute-class-in.md
@@ -1,0 +1,11 @@
+{class="some-class(value)"}
+[Some text here!](/link){class="link(variant)" target="_blank"}
+
+{.-hello}
+Some text
+
+{.smile-😎 .yolo}
+Some text
+
+{id="smile-😎"}
+Some text

--- a/tests/data/attribute-class-out.html
+++ b/tests/data/attribute-class-out.html
@@ -1,0 +1,4 @@
+<p class="some-class(value)"><a class="link(variant)" target="_blank" href="/link" rel="noopener noreferrer">Some text here!</a></p>
+<p class="-hello">Some text</p>
+<p class="smile-😎 yolo">Some text</p>
+<p id="smile-😎">Some text</p>

--- a/tests/data/attribute-class-out.md
+++ b/tests/data/attribute-class-out.md
@@ -1,0 +1,11 @@
+{.some-class(value)}
+[Some text here!](/link){.link(variant) target="_blank"}
+
+{.-hello}
+Some text
+
+{.smile-😎 .yolo}
+Some text
+
+{#smile-😎}
+Some text

--- a/tests/data/html-siblings-in.md
+++ b/tests/data/html-siblings-in.md
@@ -1,0 +1,20 @@
+# First case
+
+<p>Intro</p>
+
+<pre><code>Multiline
+
+code</code></pre>
+
+# Second case
+
+<p>Intro</p>
+<pre><code>Multiline
+code</code></pre>
+
+# Third case
+
+<p>Intro</p>
+<pre><code>Multiline
+
+code</code></pre>

--- a/tests/data/html-siblings-out.html
+++ b/tests/data/html-siblings-out.html
@@ -1,0 +1,16 @@
+<h1>First case</h1>
+<p>Intro</p>
+<pre><code>Multiline
+
+code
+</code></pre>
+<h1>Second case</h1>
+<p>Intro</p>
+<pre><code>Multiline
+code
+</code></pre>
+<h1>Third case</h1>
+<p>Intro</p>
+<pre><code>Multiline
+</code></pre>
+<p>code</p>

--- a/tests/data/html-siblings-out.md
+++ b/tests/data/html-siblings-out.md
@@ -1,0 +1,28 @@
+# First case
+
+Intro
+
+```
+Multiline
+
+code
+```
+
+# Second case
+
+Intro
+
+```
+Multiline
+code
+```
+
+# Third case
+
+Intro
+
+```
+Multiline
+```
+
+code

--- a/tests/data/ordered_lists-in.md
+++ b/tests/data/ordered_lists-in.md
@@ -1,0 +1,6 @@
+1. one
+1. two
+1. three
+    1. three dot one
+    1. three dot two
+1. four

--- a/tests/data/ordered_lists-out.html
+++ b/tests/data/ordered_lists-out.html
@@ -1,0 +1,11 @@
+<ol>
+<li>one</li>
+<li>two</li>
+<li>three
+<ol>
+<li>three dot one</li>
+<li>three dot two</li>
+</ol>
+</li>
+<li>four</li>
+</ol>

--- a/tests/data/ordered_lists-out.md
+++ b/tests/data/ordered_lists-out.md
@@ -1,0 +1,6 @@
+1. one
+2. two
+3. three
+    1. three dot one
+    2. three dot two
+4. four

--- a/tests/data/pre-broken-in.md
+++ b/tests/data/pre-broken-in.md
@@ -1,0 +1,6 @@
+<p>Header</p>
+<pre><code>Some code
+
+Broken
+
+<p>Footer</p>

--- a/tests/data/pre-broken-out.html
+++ b/tests/data/pre-broken-out.html
@@ -1,0 +1,6 @@
+<p>Header</p>
+<pre><code>Some code
+
+Broken
+
+<p>Footer</p></code></pre>

--- a/tests/data/pre-broken-out.md
+++ b/tests/data/pre-broken-out.md
@@ -1,0 +1,7 @@
+Header
+
+<pre><code>Some code
+
+Broken
+
+<p>Footer</p></code></pre>


### PR DESCRIPTION
Because the commonmark HTML parsing algorithm is what it is, some cases can produce a strange AST.

For example,

```
<p>Intro</p>
<pre><code>Multiline

code
</code></pre>
```

will be parsed as:

```
<document xmlns="http://commonmark.org/xml/1.0">
  <html_block>&lt;p&gt;Intro&lt;/p&gt;
&lt;pre&gt;&lt;code&gt;Multiline</html_block>
  <paragraph>
    <text>code</text>
    <softbreak />
    <html_inline>&lt;/code&gt;</html_inline>
    <html_inline>&lt;/pre&gt;</html_inline>
  </paragraph>
</document>
```

while (note the extra line between the first two HTML nodes)


```
<p>Intro</p>

<pre><code>Multiline

code
</code></pre>
```

will be parsed as:

```
<document xmlns="http://commonmark.org/xml/1.0">
  <html_block>&lt;p&gt;Intro&lt;/p&gt;</html_block>
  <html_block>&lt;pre&gt;&lt;code&gt;Multiline

code
&lt;/code&gt;&lt;/pre&gt;</html_block>
</document>
```

This is perfectly in line with the specs of Commonmark, but was leading to situations where the HtmlBlockFixer could not correctly transform the input HTML into markdown and was generating errors. This PR fixes such a behavior.